### PR TITLE
Fix that CI test doesn't respect matrix.python-version

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,18 +21,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          version: "latest"
-      
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      - name: Install uv and set the Python ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
       
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --locked --dev
       
       - name: Run tests
         run: uv run pytest -v


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update CI to set matrix Python via `setup-uv@v7` and install dependencies with a locked resolve.
> 
> - **CI** (`.github/workflows/ci-tests.yml`):
>   - Replace separate `setup-uv@v5` and `actions/setup-python@v6` with `astral-sh/setup-uv@v7` that sets `python-version` from the matrix.
>   - Use locked dependency installation: `uv sync --locked --dev`.
>   - Keep test execution via `uv run pytest -v`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d8d6d9afd68c485a223ded5fddd5c962f6c796. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->